### PR TITLE
Pull the ::process lambda out to its own method

### DIFF
--- a/jda-nas/src/main/java/com/sedmelluq/discord/lavaplayer/jdaudp/NativeAudioSendFactory.java
+++ b/jda-nas/src/main/java/com/sedmelluq/discord/lavaplayer/jdaudp/NativeAudioSendFactory.java
@@ -32,7 +32,7 @@ public class NativeAudioSendFactory implements IAudioSendFactory {
 
     scheduler.scheduleAtFixedRate(this::populateQueues, 0, 40, TimeUnit.MILLISECONDS);
 
-    Thread thread = new Thread(queueManager::process);
+    Thread thread = new Thread(process(queueManager));
     thread.setPriority((Thread.NORM_PRIORITY + Thread.MAX_PRIORITY) / 2);
     thread.setDaemon(true);
     thread.start();
@@ -76,5 +76,9 @@ public class NativeAudioSendFactory implements IAudioSendFactory {
         system.populateQueue(queueManager);
       }
     }
+  }
+
+  private static Runnable process(UdpQueueManager unbake) {
+	  return unbake::process;
   }
 }


### PR DESCRIPTION
This prevents the compiler inserting an implicit reference to `this`
which probably retains the entire JDA object model, because of JNI GC roots.